### PR TITLE
Fix issue when point is in org src block header

### DIFF
--- a/aggressive-fill-paragraph.el
+++ b/aggressive-fill-paragraph.el
@@ -67,12 +67,20 @@ Bulleted by *, + or -."
        (or (eql (org-element-type (org-element-at-point)) 'table)
            (eql (org-element-type (org-element-at-point)) 'table-row))))
 
+(defun afp-in-org-src-block-header? ()
+  (let ((case-fold-search t))
+    (and (derived-mode-p 'org-mode)
+         (save-excursion
+           (beginning-of-line)
+           (looking-at-p "^[ \t]*#\\+\\(\\(begin\\|end\\)_src\\|header\\|name\\)")))))
+
 (defcustom afp-suppress-fill-pfunction-list
   (list
    #'afp-repeated-whitespace?
    #'afp-markdown-inside-code-block?
    #'afp-bullet-list-in-comments?
    #'afp-in-org-table?
+   #'afp-in-org-src-block-header?
    )
   "Functions to check if filling should be suppressed.
 

--- a/features/org.feature
+++ b/features/org.feature
@@ -21,6 +21,40 @@ Scenario: org mode
     | a | b | c |
     """
 
+  Scenario: Disable inside org src-block header
+    When I insert:
+    """
+    #+HEADER:
+    #+BEGIN_SRC emacs-lisp
+    (print "Hello, world!")
+    #+END_SRC
+    """
+    When I place the cursor after ":"
+    When I type " :results output"
+    Then I should see:
+    """
+    #+HEADER: :results output
+    #+BEGIN_SRC emacs-lisp
+    (print "Hello, world!")
+    #+END_SRC
+    """
+
+  Scenario: Disable inside org src-block begin line
+    When I insert:
+    """
+    #+BEGIN_SRC emacs-lisp
+    (print "Hello, world!")
+    #+END_SRC
+    """
+    When I place the cursor after "lisp"
+    When I type " :results output"
+    Then I should see:
+    """
+    #+BEGIN_SRC emacs-lisp :results output
+    (print "Hello, world!")
+    #+END_SRC
+    """
+
   Scenario: Org comment wrapping doesn't trigger errors
     When I insert "#"
     When I type " Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque porttitor est justo, sed dignissim enim "


### PR DESCRIPTION
When point is in a org src block header, eg. `#+begin_src` or `#+header:` line, automatic fill will cause the cursor moving to the beginning of src block content and insert a whitespace there. This is unwanted behavior and it makes inserting header args impossible. So we disable filling when point is in such lines.